### PR TITLE
Fix [TypeError: Invalid JPG, marker table corrupted]

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,4 @@ module.exports = function(s3, bucket, key, callback) {
     }
     return callback(null, dimensions, buffer.length);
   });
-
-  req.send();
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/chazmo03/s3-image-size",
   "dependencies": {
-    "image-size": "^0.3.5"
+    "image-size": "^0.5.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.2.12",


### PR DESCRIPTION
The main thing fixed here is removing  `req.send()` which was essentially creating a second request with the same handlers. So on `'data'` would be called twice for every chunk corrupting the buffer. 

I guess it was only an issue when S3 started streaming the second request before finding the dimensions which happens super fast in most cases, but testing locally it seemed to happen about one our of every 10 runs or so. When it did my request to get 150 image sizes was held up by the one or two that corrupted and needed to download the entire file before giving up with a `[TypeError: Invalid JPG, marker table corrupted]`.

Also updated the `image-size` dependency to the latest version.